### PR TITLE
Remove the shiny-bound-input class to fix jscolorInput() not registering

### DIFF
--- a/R/jscolor.R
+++ b/R/jscolor.R
@@ -62,7 +62,8 @@ jscolorInput <- function(inputId, label, value, position = 'bottom', color = 'tr
     if (missing(label)) { tags$p(" ") } else if (!is.null(label)) { tags$p(label) },
     tags$input(id = inputId,
                value = ifelse(!missing(value), value, "#000000"),
-               class = sprintf("color {hash:true, pickerPosition:'%s', pickerBorderColor:'transparent', pickerFaceColor:'%s', pickerMode:'%s', slider:%s, pickerClosable:%s} shiny-bound-input", position, color, mode, tolower(slider), tolower(close)),
+               class = sprintf("color {hash:true, pickerPosition:'%s', pickerBorderColor:'transparent', pickerFaceColor:'%s', pickerMode:'%s', slider:%s, pickerClosable:%s}",
+                               position, color, mode, tolower(slider), tolower(close)),
                onchange = sprintf("$('#%s').trigger('afterChange')", inputId)),
     tags$script(sprintf("$('#%s').trigger('afterChange')", inputId))
   )


### PR DESCRIPTION
This fixes the inputs from `jscolorInput()` not being populated, which led to some crashes when trying to dereference values that were left at `NULL`.  Fixes #21.