### PR TITLE
Fix crash in the abanico app due to stricter Luminescence validation

### DIFF
--- a/inst/shiny/abanico/server.R
+++ b/inst/shiny/abanico/server.R
@@ -375,7 +375,7 @@ function(input, output, session) {
                 kde = input$kde,
                 hist = input$histogram,
                 dots = input$dots,
-                frame = input$frame)
+                frame = as.integer(input$frame))
   })
 
   # render Abanico Plot


### PR DESCRIPTION
This is necessary due to https://github.com/R-Lum/Luminescence/commit/fecca5b539c60bb6ca330b3efddb7f4ed9b6f87d.