### PR TITLE
Rewrite printCode() to allow for more flexibility

### DIFF
--- a/inst/shiny/KDE/server.R
+++ b/inst/shiny/KDE/server.R
@@ -179,20 +179,23 @@ function(input, output, session) {
       need(expr = input$xlim, message = ''),
       need(expr = input$bw, message = 'Waiting for data... Please wait!')
     )
-    
+
     do.call(plot_KDE, args = values$args)
   })##EndOf::renderPlot({})
-  
-  
+
+
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 2, 
-                              fun = "plot_KDE(data,", args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 2,
+                              list(name = "plot_KDE",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "plot_KDE", args = values$args)
   })

--- a/inst/shiny/KDE/server.R
+++ b/inst/shiny/KDE/server.R
@@ -187,7 +187,7 @@ function(input, output, session) {
   observe({
     # nested renderText({}) for code output on "R plot code" tab
     code.output <- callModule(RLumShiny:::printCode, "printCode",
-                              n_inputs = 2,
+                              n_inputs = ifelse(!all(is.na(unlist(values$data_secondary))), 2, 1),
                               list(name = "plot_KDE",
                                    arg1 = "data",
                                    args = values$args))

--- a/inst/shiny/abanico/server.R
+++ b/inst/shiny/abanico/server.R
@@ -396,8 +396,10 @@ function(input, output, session) {
   observe({
     # nested renderText({}) for code output on "R plot code" tab
     code.output <- callModule(RLumShiny:::printCode, "printCode",
-                              n_input = ifelse(!all(is.na(unlist(values$data_secondary))), 2, 1),
-                              fun = "plot_AbanicoPlot(data,", args = values$args)
+                              n_inputs = ifelse(!all(is.na(unlist(values$data_secondary))), 2, 1),
+                              list(name = "plot_AbanicoPlot",
+                                   arg1 = "data",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/aliquotsize/server.R
+++ b/inst/shiny/aliquotsize/server.R
@@ -89,8 +89,10 @@ function(input, output, session) {
     } else {
       values$args$packing.density <- NULL
     }
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 0,
-                              fun = "calc_AliquotSize(", args = values$args)
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 0,
+                              list(name = "calc_AliquotSize",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/doserecovery/server.R
+++ b/inst/shiny/doserecovery/server.R
@@ -226,13 +226,16 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 2, 
-                              fun = "plot_DRTResults(data,", args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 2,
+                              list(name = "plot_DRTResults",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "plot_DRTResults", args = values$args)
   })

--- a/inst/shiny/doseresponsecurve/server.R
+++ b/inst/shiny/doseresponsecurve/server.R
@@ -58,6 +58,7 @@ function(input, output, session) {
 
     values$args.plot <- list(
       # plot_DoseResponseCurve arguments
+      object = NULL, # will be set further down
       plot_extended = input$extended,
       density_rug = input$density_rug,
       box = input$box,
@@ -94,11 +95,16 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    args <- values$args.plot
     code.output <- callModule(RLumShiny:::printCode, "printCode",
-                              n_input = 1,
-                              fun = "plot_DoseResponseCurve(object = data,",
-                              args = args)
+                              n_inputs = 1,
+                              list(name = "fit_DoseResponseCurve",
+                                   arg1 = "data",
+                                   args = values$args.fit,
+                                   rets = "fit"),
+                              list(name = "plot_DoseResponseCurve",
+                                   arg1 = "fit",
+                                   args = values$args.plot)
+                              )
 
     output$plotCode <- renderText(code.output)
 

--- a/inst/shiny/fading/server.R
+++ b/inst/shiny/fading/server.R
@@ -93,18 +93,19 @@ function(input, output, session) {
     
     values$results_corr <- try(do.call(calc_FadingCorr, values$args_corr))
   })
-  
-  
-  
+
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1, 
-                              fun = "analyse_FadingMeasurement(data,", args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "analyse_FadingMeasurement",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "analyse_FadingMeasurement", args = values$args)
   })
@@ -118,22 +119,20 @@ function(input, output, session) {
       gval <- c(values$results@data$fading_results$FIT, values$results@data$fading_results$SD)
       tc <- values$results@data$fading_results$TC
     }
-    
-    
-    paste(
-      "# To reproduce the plot in your local R environment",
-      "# copy and run the following code to your R console.",
-      "library(Luminescence)", "\n",
-      "calc_FadingCorr(",
-      paste0("age.faded = c(", values$args_corr$age.faded[1], ", ",  values$args_corr$age.faded[2], "),"),
-      paste0("g_value = c(", gval[1], ", ", gval[2], "),"),
-      paste0("tc = ", tc, ", "),
-      paste0("tc.g_value = ", input$tc_gval, ","),
-      paste0("n.MC = 1000)"),
-      
-      sep = "\n")
+
+    args <- list(dummy = NA, # the first argument is removed by printCode()
+                 age.faded = c(values$args_corr$age.faded[1],
+                               values$args_corr$age.faded[2]),
+                 g_value = c(gval[1], gval[2]),
+                 tc = tc,
+                 tc.g_value = input$tc_gval,
+                 n.MC = 1000)
+    callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 0,
+                              list(name = "calc_FadingCorr",
+                                   args = args))
   })
-  
+
   output$results <- renderText({
     if (is.null(values$results))
       return(NULL)
@@ -167,5 +166,5 @@ function(input, output, session) {
       tags$b("Age "), tags$em("(corrected): "), signif(res$AGE, 3), " &plusmn; ", signif(res$AGE.ERROR, 3), " ka"
     ))
   })
-  
+
 }##EndOf::function(input, output)

--- a/inst/shiny/fastratio/Server.R
+++ b/inst/shiny/fastratio/Server.R
@@ -129,19 +129,21 @@ function(input, output, session) {
       tags$b("L3 end: "), signif(res$t_L3_end, 2), " / ", res$Ch_L3_end, " / ", signif(res$Cts_L3, 2)
     ))
   })
-  
+
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1, 
-                              fun = "calc_FastRatio(data,", args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "calc_FastRatio",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "calc_FastRatio", args = values$args)
   })
-  
-  
+
 }##EndOf::function(input, output)

--- a/inst/shiny/finitemixture/server.R
+++ b/inst/shiny/finitemixture/server.R
@@ -78,8 +78,11 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1,
-                              fun = "calc_FiniteMixture(data,", args = values$args)
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "calc_FiniteMixture",
+                                   arg1 = "data",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/histogram/server.R
+++ b/inst/shiny/histogram/server.R
@@ -104,21 +104,23 @@ function(input, output, session) {
     validate(need(input$xlim, "Just wait a second..."))
     do.call(plot_Histogram, args = values$args)
   })##EndOf::renderPlot({})
-  
+
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1, 
-                              fun = "plot_Histogram(data,", args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "plot_Histogram",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "plot_Histogram", args = values$args)
   })
-  
-  
+
   # renderTable() that prints the data to the second tab
   output$dataset<- DT::renderDT(
     options = list(pageLength = 10, autoWidth = FALSE),

--- a/inst/shiny/huntley2006/server.R
+++ b/inst/shiny/huntley2006/server.R
@@ -87,8 +87,11 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1,
-                              fun = "calc_Huntley2006(data,", args = values$args)
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "calc_Huntley2006",
+                                   arg1 = "data",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/irsarRF/server.R
+++ b/inst/shiny/irsarRF/server.R
@@ -107,13 +107,15 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    fun <- 'data <- set_RLum("RLum.Analysis",
-                 records = list(set_RLum("RLum.Data.Curve", data = as.matrix(data)),
+    lum <- '# create an RLum.Analysis object
+data <- set_RLum("RLum.Analysis",
+                 records = list(set_RLum("RLum.Data.Curve", data = as.matrix(data1)),
                                 set_RLum("RLum.Data.Curve", data = as.matrix(data2))))'
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 2,
-                              join_inputs_in_list = FALSE,
-                              fun = paste0(fun, "\nanalyse_IRSAR.RF(data,"),
-                              args = values$args)
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 2, join_inputs_into_list = FALSE,
+                              list(name = paste0(lum, "\n\nanalyse_IRSAR.RF"),
+                                   arg1 = "data",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/lmcurve/server.R
+++ b/inst/shiny/lmcurve/server.R
@@ -116,9 +116,10 @@ function(input, output, session) {
   observe({
     # nested renderText({}) for code output on "R plot code" tab
     code.output <- callModule(RLumShiny:::printCode, "printCode",
-                              n_input = 2, join_inputs_in_list = FALSE,
-                              fun = "fit_LMCurve(values = data,\nvalues.bg = data2,",
-                              args = values$args[-2]) # remove values.bg
+                              n_inputs = 2, join_inputs_into_list = FALSE,
+                              list(name = "fit_LMCurve",
+                                   arg1 = "values = data1,\nvalues.bg = data2",
+                                   args = values$args[-2])) # remove values.bg
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/portableOSL/server.R
+++ b/inst/shiny/portableOSL/server.R
@@ -90,8 +90,11 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1,
-                              fun = "analyse_portableOSL(data,", args = values$args)
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "analyse_portableOSL",
+                                   arg1 = "data",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/radialplot/server.R
+++ b/inst/shiny/radialplot/server.R
@@ -296,17 +296,20 @@ function(input, output, session) {
     do.call(plot_RadialPlot, args = values$args)
     
   })##EndOf::renderPlot({})
-  
+
   observe({
-    
+
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 2, 
-                              fun = "plot_RadialPlot(data,", args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 2,
+                              list(name = "plot_RadialPlot",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "plot_RadialPlot", args = values$args)
     

--- a/inst/shiny/radialplot/server.R
+++ b/inst/shiny/radialplot/server.R
@@ -301,7 +301,7 @@ function(input, output, session) {
 
     # nested renderText({}) for code output on "R plot code" tab
     code.output <- callModule(RLumShiny:::printCode, "printCode",
-                              n_inputs = 2,
+                              n_inputs = ifelse(!all(is.na(unlist(values$data_secondary))), 2, 1),
                               list(name = "plot_RadialPlot",
                                    arg1 = "data",
                                    args = values$args))

--- a/inst/shiny/scalegamma/server.R
+++ b/inst/shiny/scalegamma/server.R
@@ -96,29 +96,32 @@ function(instance, td, row, col, prop, value, cellProperties) {
       plot_single = TRUE,
       verbose = FALSE
     )
-    
+
     # sanitise final list by removing all NULL elements
     args[sapply(args, is.null)] <- NULL
-    
+
     # return
     values$args <- args
   })
-  
-  
+
+
   ## SHINY MODULES ----
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1, 
-                              fun = paste0("scale_GammaDose(data,"), args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "scale_GammaDose",
+                                   arg1 = "data",
+                                   args = values$args))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "scale_GammaDose", args = values$args)
   })
-  
+
   ## MAIN ----
   
   ## Calculate results

--- a/inst/shiny/surfaceexposure/server.R
+++ b/inst/shiny/surfaceexposure/server.R
@@ -236,8 +236,11 @@ function(input, output, session) {
 
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1,
-                              fun = paste0("fit_SurfaceExposure(data,"), args = values$args)
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = "fit_SurfaceExposure",
+                                   arg1 = "data",
+                                   args = values$args))
 
     output$plotCode<- renderText({
       code.output

--- a/inst/shiny/transformCW/Server.R
+++ b/inst/shiny/transformCW/Server.R
@@ -126,18 +126,21 @@ function(input, output, session) {
       },#EO content =,
       contentType = "text"
     )#EndOf::dowmloadHandler()
-    
+
   })
-  
+
   observe({
     # nested renderText({}) for code output on "R plot code" tab
-    code.output <- callModule(RLumShiny:::printCode, "printCode", n_input = 1, 
-                              fun = paste0(input$method, "(data,"), args = values$args)
-    
+    code.output <- callModule(RLumShiny:::printCode, "printCode",
+                              n_inputs = 1,
+                              list(name = input$method,
+                                   arg1 = "data",
+                                   args = values$pargs))
+
     output$plotCode<- renderText({
       code.output
     })##EndOf::renderText({})
-    
+
     callModule(RLumShiny:::exportCodeHandler, "export", code = code.output)
     callModule(RLumShiny:::exportPlotHandler, "export", fun = "plot", args = values$pargs)
   })


### PR DESCRIPTION
Now `printCode()` supports writing out multiple function calls, where each function is defined as a list of name, first argument, other arguments and an optional return value. This provides the functionality required to support the `doseresponsecurve` app, which uses two functions, the second of which uses the object returned by the first.

All other uses of `printCode()` have been updated to the new interface.

Fixes #75.