### PR TITLE
Fix crash when setting the percentile range in the abanico app

### DIFF
--- a/NEWS.Rmd
+++ b/NEWS.Rmd
@@ -11,6 +11,8 @@ output: github_document
     entire plot in a separate window.
   + Show the ui elements regarding the secondary dataset only when the
     corresponding data is present.
+  + Fix crash occurring when the custom percentile range was a single-digit
+    value (#110).
 
 * App `doserecovery`:
   + Show the ui elements regarding the secondary dataset only when the

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
     entire plot in a separate window.
   - Show the ui elements regarding the secondary dataset only when the
     corresponding data is present.
+  - Fix crash occurring when the custom percentile range was a
+    single-digit value (#110).
 - App `doserecovery`:
   - Show the ui elements regarding the secondary dataset only when the
     corresponding data is present.

--- a/inst/shiny/abanico/server.R
+++ b/inst/shiny/abanico/server.R
@@ -315,7 +315,7 @@ function(input, output, session) {
     centrality <- ifelse(input$centrality == "custom", input$centralityNumeric, input$centrality)
 
     # check whether predefined or custom dispersion
-    dispersion<- ifelse(input$dispersion == "custom", paste("p", input$cinn, sep=""), input$dispersion)
+    dispersion <- ifelse(input$dispersion == "custom", sprintf("p%02d", input$cinn), input$dispersion)
 
     # save all arguments in a list
     values$args<- list(data = values$data,

--- a/inst/shiny/abanico/ui.R
+++ b/inst/shiny/abanico/ui.R
@@ -173,13 +173,15 @@ function(request) {
                                                              "Custom percentile range" = "custom")),
                                             title = "Measure of dispersion, used for drawing the polygon that depicts the spread in the dose distribution."),
 
-                                        conditionalPanel(condition = "input.dispersion == 'custom'",
-                                                         numericInput(inputId = "cinn",
-                                                                      label = "x % percentile",
-                                                                      value = 25,
-                                                                      min = 0,
-                                                                      max = 100,
-                                                                      step = 1)),
+                                        div(align = "left",
+                                            conditionalPanel(condition = "input.dispersion == 'custom'",
+                                                             sliderInput(inputId = "cinn",
+                                                                         label = "Lower percentile [%]",
+                                                                         value = 25,
+                                                                         min = 0,
+                                                                         max = 50,
+                                                                         step = 1)),
+                                            title = "Symmetric percentile range with e.g. `5` indicating the range between 5 and 95 %"),
 
                                         div(align = "center", HTML("<h5>2&sigma; bar</h5>")),
 


### PR DESCRIPTION
This modifies the input type so that we have more control on what values are allowed, and adds a documentation tooltip.

Fixes #110.