### PR TITLE
Register the input handler for the filter app

### DIFF
--- a/R/chooser.R
+++ b/R/chooser.R
@@ -5,6 +5,14 @@
 chooserInput <- function(inputId, leftLabel, rightLabel, leftChoices, rightChoices,
                          size = 15, multiple = FALSE) {
 
+  ## input handler registration required for the filter app
+  shiny::registerInputHandler("shinyjsexamples.chooser", function(data, ...) {
+    if (is.null(data))
+      NULL
+    else
+      list(left=as.character(data$left), right=as.character(data$right))
+  }, force = TRUE)
+
   leftChoices <- lapply(leftChoices, tags$option)
   rightChoices <- lapply(rightChoices, tags$option)
 


### PR DESCRIPTION
This reverts the removal of the input handler registration that occurred in 7950881. No NEWS as this change was not released yet.

Fixes #113.